### PR TITLE
HTTPS Update

### DIFF
--- a/partials/_help_videos.php
+++ b/partials/_help_videos.php
@@ -15,7 +15,7 @@
 <div class="help-video" id="current-meeting-list-video" style="overflow: hidden !important;display:none; height:650px !important; width:900px !important;">
     <span class="b-close"><span>X</span></span>
     <video preload="none" id="myVideo" width="900" height="650" controls="controls">
-        <source type="video/youtube" src="http://youtu.be/qG5Iu1vtCU0?vq=hd1080" />
+        <source type="video/youtube" src="https://www.youtube.com/watch?v=qG5Iu1vtCU0&feature=youtu.be&vq=hd1080" />
         Your browser does not support HTML5 video.
     </video>
 </div>

--- a/partials/_meeting_list_setup.php
+++ b/partials/_meeting_list_setup.php
@@ -8,7 +8,7 @@ if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {
             <h3 class="help-accordian"><strong>Read This Section First</strong></h3>
             <div>
                 <h2>Getting Started</h2>
-                <p>bread is first activated using a "Tri Fold - Landscape - Letter Size" layout. This is a "starter" meeting list that uses an Area with about 100 meetings.  The starter meeting list will contain standard content for a basic meeting list that can be printed on a home computer.  A basic NA logo will be added to your media libray.  The starter meeting list uses a logo being hosted on <a target="_blank" href="http://nameetinglist.org">http://nameetinglist.org</a>.</p>
+                <p>bread is first activated using a "Tri Fold - Landscape - Letter Size" layout. This is a "starter" meeting list that uses an Area with about 100 meetings.  The starter meeting list will contain standard content for a basic meeting list that can be printed on a home computer.  A basic NA logo will be added to your media libray.  The starter meeting list uses a logo being hosted on <a target="_blank" href="https://nameetinglist.org">https://nameetinglist.org</a>.</p>
                 <h2>Step 1.</h2>
                 <p>Click on the BMLT Server tab to the left.  Change the BMLT Server and click the Save Changes button.</p>
                 <p><em>To find your BMLT Server click on the red question (?) mark.</em></p>

--- a/partials/_meetings_setup.php
+++ b/partials/_meetings_setup.php
@@ -17,7 +17,7 @@ if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {
                         <h3 class="help-accordian">Instructions</h3>
                         <div class="videocontent">
                             <video id="my_video_1"  style="width:100%;height:100%;" controls width="100%" height="100%" preload="auto">
-                                <source src="http://nameetinglist.org/videos/meeting_group_header.mp4" type="video/mp4">
+                                <source src="https://nameetinglist.org/videos/meeting_group_header.mp4" type="video/mp4">
                                 Your browser does not support HTML5 video.
                             </video>
                         </div>
@@ -162,7 +162,7 @@ if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {
                         <h3 class="help-accordian">Instructions</h3>
                         <div class="videocontent">
                             <video id="my_video_1"  style="width:100%;height:100%;" controls width="100%" height="100%" preload="auto">
-                                <source src="http://nameetinglist.org/videos/nameetinglist.mp4" type="video/mp4">
+                                <source src="https://nameetinglist.org/videos/nameetinglist.mp4" type="video/mp4">
                                 Your browser does not support HTML5 video.
                             </video>
                         </div>
@@ -343,7 +343,7 @@ if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {
                                     <h3 class="help-accordian">Instructions</h3>
                                     <div class="videocontent">
                                         <video id="my_video_1"  style="width:100%;height:100%;" controls width="100%" height="100%" preload="auto">
-                                            <source src="http://nameetinglist.org/videos/show_area_service_meetings.mp4" type="video/mp4">
+                                            <source src="https://nameetinglist.org/videos/show_area_service_meetings.mp4" type="video/mp4">
                                             Your browser does not support HTML5 video.
                                         </video>
                                     </div>


### PR DESCRIPTION
A number of the video links in the admin were still using http. Most were linked to the nameetinglist.org site which has been update to https. The other was to youTube. This is just changing http to https so that there aren't console warnings on https sites.