### PR TITLE
2.10.5 branch

### DIFF
--- a/admin/class-bread-admin.php
+++ b/admin/class-bread-admin.php
@@ -646,6 +646,11 @@ class Bread_Admin
                 isset($_POST['booklet_pages']) ?
                     boolval($_POST['booklet_pages']) : false
             );
+            $this->bread->setOption(
+                'booklet_columns',
+                isset($_POST['booklet_columns']) ?
+                    intval($_POST['booklet_columns']) : 1
+            );
             $this->bread->setOption('meeting_sort', sanitize_text_field($_POST['meeting_sort']));
             $this->bread->setOption('main_grouping', sanitize_text_field($_POST['main_grouping']));
             $this->bread->setOption('subgrouping', sanitize_text_field($_POST['subgrouping']));
@@ -676,7 +681,12 @@ class Bread_Admin
             $this->bread->setOption('used_format_1', isset($_POST['used_format_1']) ? sanitize_text_field($_POST['used_format_1']) : '');
             $this->bread->setOption('recurse_service_bodies', isset($_POST['recurse_service_bodies']) ? 1 : 0);
             $this->bread->setOption('extra_meetings_enabled', isset($_POST['extra_meetings_enabled']) ? intval($_POST['extra_meetings_enabled']) : 0);
-            $this->bread->setOption('include_protection', boolval($_POST['include_protection']));
+            $this->bread->setOption('include_protection', boolval($_POST['include_protection'] ?? false));
+            if ($_POST['include_protection'] ?? false) {
+                $this->bread->setOption('protection_password', sanitize_text_field($_POST['protection_password']));
+            } else {
+                $this->bread->setOption('protection_password', '');
+            }
             $this->bread->setOption('weekday_language', sanitize_text_field($_POST['weekday_language']));
             $this->bread->setOption('additional_list_language', sanitize_text_field($_POST['additional_list_language']));
             $this->bread->setOption('weekday_start', sanitize_text_field($_POST['weekday_start']));
@@ -701,7 +711,6 @@ class Bread_Admin
             $this->bread->setOption('base_font', sanitize_text_field($_POST['base_font']));
             $this->bread->setOption('colorspace', sanitize_text_field($_POST['colorspace']));
             $this->bread->setOption('wheelchair_size', sanitize_text_field($_POST['wheelchair_size']));
-            $this->bread->setOption('protection_password', sanitize_text_field($_POST['protection_password']));
             $this->bread->setOption('time_clock', sanitize_text_field($_POST['time_clock']));
             $this->bread->setOption('time_option', intval($_POST['time_option']));
             $this->bread->setOption('remove_space', boolval($_POST['remove_space']));

--- a/admin/class-bread-admin.php
+++ b/admin/class-bread-admin.php
@@ -578,7 +578,7 @@ class Bread_Admin
             if (!$this->current_user_can_modify()) {
                 return;
             }
-            if ($this->bread->getRequestedSetting() == 1) {
+            if ($this->bread->getRequestedSetting() === 1) {
                 return;
             }
             $this->bread->deleteSetting($this->bread->getRequestedSetting());
@@ -610,14 +610,14 @@ class Bread_Admin
             $this->bread->setOption('front_page_line_height', $_POST['front_page_line_height']);
             $this->bread->setOption('front_page_font_size', floatval($_POST['front_page_font_size']));
             $this->bread->setOption('content_font_size', floatval($_POST['content_font_size']));
-            $this->bread->setOption('suppress_heading', floatval($_POST['suppress_heading']));
+            $this->bread->setOption('suppress_heading', isset($_POST['suppress_heading']));
             $this->bread->setOption('header_font_size', floatval($_POST['header_font_size']));
             $this->bread->setOption('header_text_color', sanitize_hex_color($_POST['header_text_color']));
             $this->bread->setOption('header_background_color', sanitize_hex_color($_POST['header_background_color']));
-            $this->bread->setOption('header_uppercase', intval($_POST['header_uppercase']));
-            $this->bread->setOption('header_bold', intval($_POST['header_bold']));
+            $this->bread->setOption('header_uppercase', isset($_POST['header_uppercase']));
+            $this->bread->setOption('header_bold', isset($_POST['header_bold']));
             $this->bread->setOption('sub_header_shown', sanitize_text_field($_POST['sub_header_shown']));
-            $this->bread->setOption('cont_header_shown', intval($_POST['cont_header_shown']));
+            $this->bread->setOption('cont_header_shown', isset($_POST['cont_header_shown']));
             $this->bread->setOption(
                 'column_gap',
                 isset($_POST['column_gap']) ?
@@ -641,16 +641,8 @@ class Bread_Admin
             $this->bread->setOption('page_size', sanitize_text_field($_POST['page_size']));
             $this->bread->setOption('page_orientation', sanitize_text_field($_POST['page_orientation']));
             $this->bread->setOption('page_fold', sanitize_text_field($_POST['page_fold']));
-            $this->bread->setOption(
-                'booklet_pages',
-                isset($_POST['booklet_pages']) ?
-                    boolval($_POST['booklet_pages']) : false
-            );
-            $this->bread->setOption(
-                'booklet_columns',
-                isset($_POST['booklet_columns']) ?
-                    intval($_POST['booklet_columns']) : 1
-            );
+            $this->bread->setOption('booklet_pages', isset($_POST['booklet_pages']));
+            $this->bread->setOption('booklet_columns', $_POST['booklet_columns'] ? intval($_POST['booklet_columns']) : 1);
             $this->bread->setOption('meeting_sort', sanitize_text_field($_POST['meeting_sort']));
             $this->bread->setOption('main_grouping', sanitize_text_field($_POST['main_grouping']));
             $this->bread->setOption('subgrouping', sanitize_text_field($_POST['subgrouping']));
@@ -660,11 +652,7 @@ class Bread_Admin
             $this->bread->setOption('city_suffix', sanitize_text_field($_POST['city_suffix']));
             $this->bread->setOption('meeting_template_content', wp_kses_post($_POST['meeting_template_content']));
             $this->bread->setOption('additional_list_template_content', wp_kses_post($_POST['additional_list_template_content']));
-            $this->bread->setOption(
-                'column_line',
-                isset($_POST['column_line']) ?
-                    boolval($_POST['column_line']) : 0
-            );
+            $this->bread->setOption('column_line', isset($_POST['column_line']));
             $this->bread->setOption(
                 'col_color',
                 isset($_POST['col_color']) ?
@@ -679,10 +667,10 @@ class Bread_Admin
                     floatval($_POST['pagenumbering_font_size']) : '9'
             );
             $this->bread->setOption('used_format_1', isset($_POST['used_format_1']) ? sanitize_text_field($_POST['used_format_1']) : '');
-            $this->bread->setOption('recurse_service_bodies', isset($_POST['recurse_service_bodies']) ? 1 : 0);
-            $this->bread->setOption('extra_meetings_enabled', isset($_POST['extra_meetings_enabled']) ? intval($_POST['extra_meetings_enabled']) : 0);
-            $this->bread->setOption('include_protection', boolval($_POST['include_protection'] ?? false));
-            if ($_POST['include_protection'] ?? false) {
+            $this->bread->setOption('recurse_service_bodies', isset($_POST['recurse_service_bodies']));
+            $this->bread->setOption('extra_meetings_enabled', isset($_POST['extra_meetings_enabled']));
+            $this->bread->setOption('include_protection', isset($_POST['include_protection']));
+            if ($this->bread->getOption('include_protection')) {
                 $this->bread->setOption('protection_password', sanitize_text_field($_POST['protection_password']));
             } else {
                 $this->bread->setOption('protection_password', '');
@@ -705,7 +693,7 @@ class Bread_Admin
                 isset($_POST['nonmeeting_footer']) ?
                     sanitize_text_field($_POST['nonmeeting_footer']) : ''
             );
-            $this->bread->setOption('include_additional_list', boolval($_POST['include_additional_list']));
+            $this->bread->setOption('include_additional_list', isset($_POST['include_additional_list']));
             $this->bread->setOption('additional_list_format_key', sanitize_text_field($_POST['additional_list_format_key']));
             $this->bread->setOption('additional_list_sort_order', sanitize_text_field($_POST['additional_list_sort_order']));
             $this->bread->setOption('base_font', sanitize_text_field($_POST['base_font']));
@@ -721,7 +709,7 @@ class Bread_Admin
             $this->bread->setOption('custom_query', sanitize_text_field($_POST['custom_query']));
             $this->bread->setOption('additional_list_custom_query', sanitize_text_field($_POST['additional_list_custom_query']));
             $this->bread->setOption('user_agent', isset($_POST['user_agent']) ? sanitize_text_field($_POST['user_agent']) : 'None');
-            $this->bread->setOption('sslverify', isset($_POST['sslverify']) ? '1' : '0');
+            $this->bread->setOption('sslverify', isset($_POST['sslverify']));
             $this->bread->setOption('extra_meetings', array());
             if (isset($_POST['extra_meetings'])) {
                 foreach ($_POST['extra_meetings'] as $extra) {

--- a/admin/class-bread-admin.php
+++ b/admin/class-bread-admin.php
@@ -701,7 +701,7 @@ class Bread_Admin
             $this->bread->setOption('wheelchair_size', sanitize_text_field($_POST['wheelchair_size']));
             $this->bread->setOption('time_clock', sanitize_text_field($_POST['time_clock']));
             $this->bread->setOption('time_option', intval($_POST['time_option']));
-            $this->bread->setOption('remove_space', boolval($_POST['remove_space']));
+            $this->bread->setOption('remove_space', boolval($_POST['remove_space']));  // It's a radio button, not a checkbox, so we can't just check isset
             $this->bread->setOption('content_line_height', floatval($_POST['content_line_height']));
             $this->bread->setOption('root_server', sanitize_url($_POST['root_server']));
             $this->bread->setOption('service_bodies', isset($_POST['service_bodies']) ? array_map('sanitize_text_field', $_POST['service_bodies']) : array());

--- a/admin/partials/_bmlt_server_setup.php
+++ b/admin/partials/_bmlt_server_setup.php
@@ -54,7 +54,7 @@ function Bread_bmlt_server_setup_page_render(Bread_AdminDisplay $breadAdmin)
                         </select>
                     </p>
                     <div>
-                        <input type="checkbox" name="recurse_service_bodies" id="recurse_service_bodies" value="1" <?php echo ($bread->getOption('recurse_service_bodies') == 1 ? 'checked' : '') ?> /> <?php esc_html_e('Recurse Service Bodies', 'bread') ?>
+                        <input type="checkbox" name="recurse_service_bodies" id="recurse_service_bodies" value="1" <?php echo ($bread->getOption('recurse_service_bodies') ? 'checked' : '') ?> /> <?php esc_html_e('Recurse Service Bodies', 'bread') ?>
                     </div>
                 </div>
             </div>
@@ -93,7 +93,7 @@ function Bread_bmlt_server_setup_page_render(Bread_AdminDisplay $breadAdmin)
                         </select>
                         <p id="extra_meetings_hint"><?php esc_html_e('Hint: Type a group name, weekday or area to narrow down your choices.', 'bread') ?></p>
                     <div>
-                        <input type="checkbox" id="extra_meetings_enabled" name="extra_meetings_enabled" value="1" <?php echo (!$bread->emptyOption('extra_meetings_enabled') && $bread->getOption('extra_meetings_enabled') == 1 ? 'checked' : '') ?> /><?php esc_html_e('Extra Meetings Enabled', 'bread') ?>
+                        <input type="checkbox" id="extra_meetings_enabled" name="extra_meetings_enabled" value="1" <?php echo ($bread->getOption('extra_meetings_enabled') ? 'checked' : '') ?> /><?php esc_html_e('Extra Meetings Enabled', 'bread') ?>
                     </div>
                 </div>
 

--- a/admin/partials/_custom_fonts_setup.php
+++ b/admin/partials/_custom_fonts_setup.php
@@ -86,13 +86,13 @@ class Bread_Custom_Fonts_Table extends WP_List_Table
         if (isset($_GET['view']) && $_GET['view'] != 'all') {
             $this->items = array_filter($this->items, function ($font) {
                 $bool = in_array($font['slug'], $this->active);
-                return ($_GET['view'] == 'active') ? $bool : !$bool;
+                return ($_GET['view'] === 'active') ? $bool : !$bool;
             });
         }
     }
     private function selected($a, $b)
     {
-        return ($a == $b) ? 'selected' : '';
+        return ($a === $b) ? 'selected' : '';
     }
     private function getAllScripts(): array
     {

--- a/admin/partials/_layout_setup.php
+++ b/admin/partials/_layout_setup.php
@@ -11,7 +11,7 @@ function echo_font_options(string $base_font, Bread $bread)
             continue;
         }
         $font_info = $infos[$font_key];
-        echo '<option value="' . esc_attr($font_key) . '" ' . ($base_font == $font_key ? 'selected="selected"' : '') . '>' . esc_html($font_info['name']) . '</option>';
+        echo '<option value="' . esc_attr($font_key) . '" ' . ($base_font === $font_key ? 'selected="selected"' : '') . '>' . esc_html($font_info['name']) . '</option>';
     }
 }
 function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
@@ -72,32 +72,32 @@ function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
                     <input name="bread_version" value=<?php echo esc_html(BREAD_VERSION); ?> type="hidden">
                     <div style="display:flex;">
                         <div style="border:solid;flex:1;margin-right:10px;padding:2px 6px 6px 6px;line-height:1.5;"><?php esc_html_e('Single Page', 'bread') ?><br />
-                            <input class="mlg single-page-check" id="flyer" type="radio" name="page_fold" value="flyer" <?php echo ($bread->getOption('page_fold') == 'flyer' ? 'checked' : '') ?>><label for="flyer"><?php esc_html_e('Flyer', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                            <input class="mlg single-page-check" id="tri" type="radio" name="page_fold" value="tri" <?php echo ($bread->getOption('page_fold') == 'tri' ? 'checked' : '') ?>><label for="tri"><?php esc_html_e('Tri-Fold', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                            <input class="mlg single-page-check" id="quad" type="radio" name="page_fold" value="quad" <?php echo ($bread->getOption('page_fold') == 'quad' ? 'checked' : '') ?>><label for="quad"><?php esc_html_e('Quad-Fold', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                            <input class="mlg single-page-check" id="pocket" type="radio" name="page_fold" value="pocket" <?php echo ($bread->getOption('page_fold') == 'pocket' ? 'checked' : '') ?>><label for="pocket"><?php esc_html_e('Pocket', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                            <input class="mlg single-page-check" id="flyer" type="radio" name="page_fold" value="flyer" <?php echo ($bread->getOption('page_fold') === 'flyer' ? 'checked' : '') ?>><label for="flyer"><?php esc_html_e('Flyer', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                            <input class="mlg single-page-check" id="tri" type="radio" name="page_fold" value="tri" <?php echo ($bread->getOption('page_fold') === 'tri' ? 'checked' : '') ?>><label for="tri"><?php esc_html_e('Tri-Fold', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                            <input class="mlg single-page-check" id="quad" type="radio" name="page_fold" value="quad" <?php echo ($bread->getOption('page_fold') === 'quad' ? 'checked' : '') ?>><label for="quad"><?php esc_html_e('Quad-Fold', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                            <input class="mlg single-page-check" id="pocket" type="radio" name="page_fold" value="pocket" <?php echo ($bread->getOption('page_fold') === 'pocket' ? 'checked' : '') ?>><label for="pocket"><?php esc_html_e('Pocket', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
                             <br />
-                            <input class="mlg single-page" id="portrait" type="radio" name="page_orientation" value="P" <?php echo ($bread->getOption('page_orientation') == 'P' ? 'checked' : '') ?>><label class="single-page" for="portrait"><?php esc_html_e('Portrait', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                            <input class="mlg single-page" id="landscape" type="radio" name="page_orientation" value="L" <?php echo ($bread->getOption('page_orientation') == 'L' ? 'checked' : '') ?>><label class="single-page" for="landscape"><?php esc_html_e('Landscape', 'bread') ?></label>
+                            <input class="mlg single-page" id="portrait" type="radio" name="page_orientation" value="P" <?php echo ($bread->getOption('page_orientation') === 'P' ? 'checked' : '') ?>><label class="single-page" for="portrait"><?php esc_html_e('Portrait', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                            <input class="mlg single-page" id="landscape" type="radio" name="page_orientation" value="L" <?php echo ($bread->getOption('page_orientation') === 'L' ? 'checked' : '') ?>><label class="single-page" for="landscape"><?php esc_html_e('Landscape', 'bread') ?></label>
                         </div>
                         <div style="border:solid;flex:1;padding:2px 6px 6px 6px;line-height:1.5;"><?php esc_html_e('Booklets', 'bread') ?><br />
-                            <input class="mlg booklet-check" id="half" type="radio" name="page_fold" value="half" <?php echo ($bread->getOption('page_fold') == 'half' ? 'checked' : '') ?>><label for="half"><?php esc_html_e('Half-Fold', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                            <input class="mlg booklet-check" id="full" type="radio" name="page_fold" value="full" <?php echo ($bread->getOption('page_fold') == 'full' ? 'checked' : '') ?>><label for="full"><?php esc_html_e('Full Page', 'bread') ?></label>
+                            <input class="mlg booklet-check" id="half" type="radio" name="page_fold" value="half" <?php echo ($bread->getOption('page_fold') === 'half' ? 'checked' : '') ?>><label for="half"><?php esc_html_e('Half-Fold', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                            <input class="mlg booklet-check" id="full" type="radio" name="page_fold" value="full" <?php echo ($bread->getOption('page_fold') === 'full' ? 'checked' : '') ?>><label for="full"><?php esc_html_e('Full Page', 'bread') ?></label>
                             <br />
-                            <input class="mlg booklet" id="booklet_pages" type="checkbox" name="booklet_pages" value="1" <?php echo ($bread->getOption('booklet_pages') == '1' ? 'checked' : '') ?> /><label class="booklet" for="booklet_pages"><?php esc_html_e('Add extra pages for booklet', 'bread') ?></label>
-                            <input class="mlg booklet" id="booklet_columns" type="checkbox" name="booklet_columns" value="2" <?php echo ($bread->getOption('booklet_columns') == '2' ? 'checked' : '') ?> /><label class="booklet" for="booklet_columns"><?php esc_html_e('2 Columns on each page', 'bread') ?></label>
+                            <input class="mlg booklet" id="booklet_pages" type="checkbox" name="booklet_pages" value="1" <?php echo ($bread->getOption('booklet_pages') ? 'checked' : '') ?> /><label class="booklet" for="booklet_pages"><?php esc_html_e('Add extra pages for booklet', 'bread') ?></label>
+                            <input class="mlg booklet" id="booklet_columns" type="checkbox" name="booklet_columns" value="2" <?php echo ($bread->getOption('booklet_columns') === 2 ? 'checked' : '') ?> /><label class="booklet" for="booklet_columns"><?php esc_html_e('2 Columns on each page', 'bread') ?></label>
                         </div>
                     </div>
                     <br />
                     <div>
                         <?php esc_html_e('Page Size:', 'bread') ?><br />
-                        <input class="mlg booklet" id="5inch" type="radio" name="page_size" value="5inch" <?php echo ($bread->getOption('page_size') == '5inch' ? 'checked' : '') ?>><label for="5inch" class="booklet"><?php esc_html_e('5 inch', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                        <input class="mlg" id="letter" type="radio" name="page_size" value="letter" <?php echo ($bread->getOption('page_size') == 'letter' ? 'checked' : '') ?>><label for="letter"><?php esc_html_e('Letter', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                        <input class="mlg" id="legal" type="radio" name="page_size" value="legal" <?php echo ($bread->getOption('page_size') == 'legal' ? 'checked' : '') ?>><label for="legal"><?php esc_html_e('Legal', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                        <input class="mlg" id="ledger" type="radio" name="page_size" value="ledger" <?php echo ($bread->getOption('page_size') == 'ledger' ? 'checked' : '') ?>><label for="ledger"><?php esc_html_e('Ledger', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                        <input class="mlg" id="A4" type="radio" name="page_size" value="A4" <?php echo ($bread->getOption('page_size') == 'A4' ? 'checked' : '') ?>><label for="A4"><?php esc_html_e('A4', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                        <input class="mlg booklet" id="A5" type="radio" name="page_size" value="A5" <?php echo ($bread->getOption('page_size') == 'A5' ? 'checked' : '') ?>><label for="A5" class="booklet"><?php esc_html_e('A5', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
-                        <input class="mlg booklet A6" id="A6" type="radio" name="page_size" value="A6" <?php echo ($bread->getOption('page_size') == 'A6' ? 'checked' : '') ?>><label for="A6" class="booklet A6"><?php esc_html_e('A6', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg booklet" id="5inch" type="radio" name="page_size" value="5inch" <?php echo ($bread->getOption('page_size') === '5inch' ? 'checked' : '') ?>><label for="5inch" class="booklet"><?php esc_html_e('5 inch', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg" id="letter" type="radio" name="page_size" value="letter" <?php echo ($bread->getOption('page_size') === 'letter' ? 'checked' : '') ?>><label for="letter"><?php esc_html_e('Letter', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg" id="legal" type="radio" name="page_size" value="legal" <?php echo ($bread->getOption('page_size') === 'legal' ? 'checked' : '') ?>><label for="legal"><?php esc_html_e('Legal', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg" id="ledger" type="radio" name="page_size" value="ledger" <?php echo ($bread->getOption('page_size') === 'ledger' ? 'checked' : '') ?>><label for="ledger"><?php esc_html_e('Ledger', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg" id="A4" type="radio" name="page_size" value="A4" <?php echo ($bread->getOption('page_size') === 'A4' ? 'checked' : '') ?>><label for="A4"><?php esc_html_e('A4', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg booklet" id="A5" type="radio" name="page_size" value="A5" <?php echo ($bread->getOption('page_size') === 'A5' ? 'checked' : '') ?>><label for="A5" class="booklet"><?php esc_html_e('A5', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
+                        <input class="mlg booklet A6" id="A6" type="radio" name="page_size" value="A6" <?php echo ($bread->getOption('page_size') === 'A6' ? 'checked' : '') ?>><label for="A6" class="booklet A6"><?php esc_html_e('A6', 'bread') ?>&nbsp;&nbsp;&nbsp;</label>
                         <div id="marginsdiv" style="border-top: 1px solid #EEE;">
                             <?php esc_html_e('Page Margin Top: ', 'bread') ?><input min="0" max="20" step="1" size="3" maxlength="3" type="number" class="bmlt-input-field" style="display:inline;" id="margin_top" name="margin_top" value="<?php echo esc_attr($bread->getOptionForDisplay('margin_top', '3')); ?>" />&nbsp;&nbsp;&nbsp;
                             <?php esc_html_e('Bottom: ', 'bread') ?><input min="0" max="20" step="1" size="3" maxlength="3" type="number" class="bmlt-input-field" style="display:inline;" id="margin_bottom" name="margin_bottom" value="<?php echo esc_attr($bread->getOptionForDisplay('margin_bottom', '3')); ?>" />&nbsp;&nbsp;&nbsp;
@@ -148,8 +148,7 @@ function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
                         <?php esc_html_e('Column Gap Width: ', 'bread') ?><input min="1" max="20" step="1" size="3" maxlength="3" type="number" class="bmlt-input-field" style="display:inline;" id="column_gap" name="column_gap" value="<?php echo esc_attr($bread->getOptionForDisplay('column_gap', '5')); ?>" />
                     </div>
                     <div id="columnseparatordiv" style="border-top: 1px solid #EEE;" class="single-page">
-                        <input class="mlg" name="column_line" value="0" type="hidden">
-                        <?php esc_html_e('Separator: ', 'bread') ?><input type="checkbox" name="column_line" value="1" <?php echo ($bread->getOption('column_line') == '1' ? 'checked' : '') ?> /></td>
+                        <?php esc_html_e('Separator: ', 'bread') ?><input type="checkbox" name="column_line" value="1" <?php echo ($bread->getOption('column_line') ? 'checked' : '') ?> /></td>
                         <label for="col_color"><?php esc_html_e('Color:', 'bread') ?></label> <input style="display: inline-block !important; width: 70px; margin-right: 5px;" type='color' class="bmlt-color" id="col_color" name="col_color" value="<?php echo esc_html($bread->getOptionForDisplay('col_color', '#bfbfbf')); ?>" />
                     </div>
                 </div>
@@ -170,10 +169,10 @@ function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
                         <input class="mlg" name="colorspace" value="0" type="hidden">
                         <label for="colorspace"><?php esc_html_e('Color space: ', 'bread') ?></label>
                         <select id="colorspace" name="colorspace">
-                            <option value="0" <?php echo $bread->getOption('colorspace') == '0' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('Unrestricted', 'bread') ?></option>
-                            <option value="1" <?php echo $bread->getOption('colorspace') == '1' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('Greyscale', 'bread') ?></option>
-                            <option value="2" <?php echo $bread->getOption('colorspace') == '2' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('RGB', 'bread') ?></option>
-                            <option value="3" <?php echo $bread->getOption('colorspace') == '3' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('CMYK', 'bread') ?></option>
+                            <option value="0" <?php echo $bread->getOption('colorspace') === '0' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('Unrestricted', 'bread') ?></option>
+                            <option value="1" <?php echo $bread->getOption('colorspace') === '1' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('Greyscale', 'bread') ?></option>
+                            <option value="2" <?php echo $bread->getOption('colorspace') === '2' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('RGB', 'bread') ?></option>
+                            <option value="3" <?php echo $bread->getOption('colorspace') === '3' ? "selected=\"selected\"" : "" ?>><?php esc_html_e('CMYK', 'bread') ?></option>
                         </select>
                     </div>
                 </div>
@@ -198,7 +197,7 @@ function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
                 <h3 class="hndle"><?php esc_html_e('Password Protection', 'bread') ?><span data-tooltip-content="#pdfpassword-tooltip-content" class="my-tooltip"><span class="tooltipster-icon">(?)</span></span></h3>
                 <div class="inside">
                     <div id="includeprotection" style="border-top: 1px solid #EEE;">
-                        <input type="checkbox" name="include_protection" value="1" <?php echo ($bread->getOption('include_protection') == '1' ? 'checked' : '') ?>><?php esc_html_e('Enable Protection', 'bread') ?>
+                        <input type="checkbox" name="include_protection" value="1" <?php echo ($bread->getOption('include_protection') ? 'checked' : '') ?>><?php esc_html_e('Enable Protection', 'bread') ?>
                         <br/>
                         <label for="protection_password"><?php esc_html_e('Password: ', 'bread') ?></label>
                         <input class="protection_pass" id="protection_password" type="password" name="protection_password" value="<?php echo esc_attr($bread->getOptionForDisplay('protection_password', '')); ?>" />

--- a/admin/partials/_layout_setup.php
+++ b/admin/partials/_layout_setup.php
@@ -85,6 +85,7 @@ function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
                             <input class="mlg booklet-check" id="full" type="radio" name="page_fold" value="full" <?php echo ($bread->getOption('page_fold') == 'full' ? 'checked' : '') ?>><label for="full"><?php esc_html_e('Full Page', 'bread') ?></label>
                             <br />
                             <input class="mlg booklet" id="booklet_pages" type="checkbox" name="booklet_pages" value="1" <?php echo ($bread->getOption('booklet_pages') == '1' ? 'checked' : '') ?> /><label class="booklet" for="booklet_pages"><?php esc_html_e('Add extra pages for booklet', 'bread') ?></label>
+                            <input class="mlg booklet" id="booklet_columns" type="checkbox" name="booklet_columns" value="2" <?php echo ($bread->getOption('booklet_columns') == '2' ? 'checked' : '') ?> /><label class="booklet" for="booklet_columns"><?php esc_html_e('2 Columns on each page', 'bread') ?></label>
                         </div>
                     </div>
                     <br />
@@ -197,12 +198,8 @@ function Bread_layout_setup_page_render(Bread_AdminDisplay $breadAdmin)
                 <h3 class="hndle"><?php esc_html_e('Password Protection', 'bread') ?><span data-tooltip-content="#pdfpassword-tooltip-content" class="my-tooltip"><span class="tooltipster-icon">(?)</span></span></h3>
                 <div class="inside">
                     <div id="includeprotection" style="border-top: 1px solid #EEE;">
-                        <input name="include_protection" value="0" type="hidden">
                         <input type="checkbox" name="include_protection" value="1" <?php echo ($bread->getOption('include_protection') == '1' ? 'checked' : '') ?>><?php esc_html_e('Enable Protection', 'bread') ?>
-                        <div style="overflow: none; height: 0px;background: transparent;" data-description="dummyPanel for Chrome auto-fill issue">
-                            <input type="text" style="height:0;width:0; background: transparent; color: transparent;border: none;" data-description="dummyUsername">
-                            <input type="password" style="height:0;width:0;background: transparent; color: transparent;border: none;" data-description="dummyPassword">
-                        </div>
+                        <br/>
                         <label for="protection_password"><?php esc_html_e('Password: ', 'bread') ?></label>
                         <input class="protection_pass" id="protection_password" type="password" name="protection_password" value="<?php echo esc_attr($bread->getOptionForDisplay('protection_password', '')); ?>" />
                     </div>

--- a/admin/partials/_meetings_setup.php
+++ b/admin/partials/_meetings_setup.php
@@ -18,8 +18,7 @@ function Bread_meetings_setup_page_render(Bread_AdminDisplay $breadAdmin)
                 <h3 class="hndle"><?php esc_html_e('Meeting Group [Column] Header', 'bread') ?><span data-tooltip-content="#columnheader-tooltip-content" class="my-tooltip"><span class="tooltipster-icon">(?)</span></span></h3>
                 <div class="inside">
                     <div>
-                        <input name="suppress_heading" value="0" type="hidden">
-                        <label for="suppress_heading"><?php esc_html_e('Suppress Heading: ', 'bread') ?></label><input type="checkbox" name="suppress_heading" id="suppress_heading" value="1" <?php echo ($bread->getOption('suppress_heading') == '1' ? 'checked' : '') ?>>
+                        <label for="suppress_heading"><?php esc_html_e('Suppress Heading: ', 'bread') ?></label><input type="checkbox" name="suppress_heading" id="suppress_heading" value="1" <?php echo ($bread->getOption('suppress_heading') ? 'checked' : '') ?>>
                         <table id="header_options_div">
                             <tr>
                                 <td style="padding-right: 10px;"><?php esc_html_e('Font Size: ', 'bread') ?><input min="4" max="18" step=".1" size="3" maxlength="3" type="number" class="bmlt-input-field" style="display:inline;" id="header_font_size" name="header_font_size" value="<?php echo esc_attr($bread->getOption('header_font_size')); ?>" /></td>
@@ -34,14 +33,11 @@ function Bread_meetings_setup_page_render(Bread_AdminDisplay $breadAdmin)
                                     </div>
                                 </td>
                                 <td style="padding-right: 10px;">
-                                    <input name="header_uppercase" value="0" type="hidden">
-                                <td><label for="header_uppercase"><?php esc_html_e('Uppercase: ', 'bread') ?></label><input type="checkbox" name="header_uppercase" value="1" <?php echo ($bread->getOption('header_uppercase') == '1' ? 'checked' : '') ?>></td>
+                                <td><label for="header_uppercase"><?php esc_html_e('Uppercase: ', 'bread') ?></label><input type="checkbox" name="header_uppercase" value="1" <?php echo ($bread->getOption('header_uppercase') ? 'checked' : '') ?>></td>
                                 <td style="padding-right: 10px;">
-                                    <input name="header_bold" value="0" type="hidden">
-                                <td><label for="header_bold"><?php esc_html_e('Bold: ', 'bread') ?></label><input type="checkbox" name="header_bold" value="1" <?php echo ($bread->getOption('header_bold') == '1' ? 'checked' : '') ?>></td>
+                                <td><label for="header_bold"><?php esc_html_e('Bold: ', 'bread') ?></label><input type="checkbox" name="header_bold" value="1" <?php echo ($bread->getOption('header_bold') ? 'checked' : '') ?>></td>
                                 <td style="padding-right: 10px;">
-                                    <input name="cont_header_shown" value="0" type="hidden">
-                                <td><label for="cont_header_shown"><?php esc_html_e('Display (Cont) Header: ', 'bread') ?></label><input type="checkbox" name="cont_header_shown" value="1" <?php echo ($bread->getOption('cont_header_shown') == '1' ? 'checked' : '') ?>></td>
+                                <td><label for="cont_header_shown"><?php esc_html_e('Display (Cont) Header: ', 'bread') ?></label><input type="checkbox" name="cont_header_shown" value="1" <?php echo ($bread->getOption('cont_header_shown') ? 'checked' : '') ?>></td>
                             </tr>
                         </table>
                     </div>
@@ -229,8 +225,7 @@ function Bread_meetings_setup_page_render(Bread_AdminDisplay $breadAdmin)
                                 <div><input class="mlg" id="option1" type="radio" name="time_option" value="1" <?php echo ($bread->getOption('time_option') == '1' || $bread->getOption('time_option') == '' ? 'checked' : '') ?>><label for="option1"></label></div>
                             </td>
                             <td style="padding-right: 30px;">
-                                <?php $checked = $bread->getOption('remove_space') == '0' || $bread->getOption('remove_space') == '' ? 'checked' : ''; ?>
-                                <div><input class="mlg recalcTimeLabel" id="two" type="radio" name="remove_space" value="0" <?php echo esc_attr($checked); ?>><label for="two"><?php esc_html_e('Add White Space', 'bread') ?></label></div>
+                                <div><input class="mlg recalcTimeLabel" id="two" type="radio" name="remove_space" value="0" <?php echo !$bread->getOption('remove_space') ? 'checked' : ''; ?>><label for="two"><?php esc_html_e('Add White Space', 'bread') ?></label></div>
                             </td>
                         </tr>
                         <tr>
@@ -241,7 +236,7 @@ function Bread_meetings_setup_page_render(Bread_AdminDisplay $breadAdmin)
                                 <div><input class="mlg" id="option2" type="radio" name="time_option" value="2" <?php echo ($bread->getOption('time_option') == '2' ? 'checked' : '') ?>><label for="option2"></label></div>
                             </td>
                             <td style="padding-right: 30px;">
-                                <div><input class="mlg recalcTimeLabel" id="four" type="radio" name="remove_space" value="1" <?php echo ($bread->getOption('remove_space') == '1') ? 'checked' : ''; ?>><label for="four"><?php esc_html_e('Remove White Space', 'bread') ?></label></div>
+                                <div><input class="mlg recalcTimeLabel" id="four" type="radio" name="remove_space" value="1" <?php echo $bread->getOption('remove_space') ? 'checked' : ''; ?>><label for="four"><?php esc_html_e('Remove White Space', 'bread') ?></label></div>
                             </td>
                         </tr>
                         </tr>
@@ -320,8 +315,7 @@ function Bread_meetings_setup_page_render(Bread_AdminDisplay $breadAdmin)
                         <label for="additional_list_custom_query"><?php esc_html_e('Custom Query: ', 'bread') ?></label>
                         <input type="text" id="additional_list_custom_query" name="additional_list_custom_query" size="100" value="<?php echo esc_attr($bread->getOption('additional_list_custom_query')) ?>" />
                     </p>
-                    <input name="include_additional_list" value="0" type="hidden">
-                    <p><input type="checkbox" name="include_additional_list" value="1" <?php echo ($bread->getOption('include_additional_list') == '1' ? 'checked' : '') ?>><?php esc_html_e('Include meetings with this format in the main list', 'bread') ?></p>
+                    <p><input type="checkbox" name="include_additional_list" value="1" <?php echo ($bread->getOption('include_additional_list') ? 'checked' : '') ?>><?php esc_html_e('Include meetings with this format in the main list', 'bread') ?></p>
                     <?php esc_html_e('If you wish to define different contents for the additional list, use this template.', 'bread') ?>
                     <div style="margin-top:0px; margin-bottom:20px; max-width:100%; width:100%;">
                         <?php

--- a/admin/tinymce/front_page_button/plugin.min.js
+++ b/admin/tinymce/front_page_button/plugin.min.js
@@ -33,9 +33,15 @@
                         text: 'Format Code Legend',
                         menu: [
                         {
-                            text: 'Used Format Codes - Abbreviated - Same language as weekdays text',
+                            text: 'Used Format Codes - Abbreviated - Same language as weekdays text/ Two Formats per Row',
                             onclick: function () {
                                 editor.insertContent('<table style="width: 100%;"><tbody><tr><td style="padding: 2pt; text-align: center; background-color: #000000;"><strong><span style="color: #fff;">Meeting Format Legend</span></strong></td></tr></tbody></table>[format_codes_used_basic]</p>');
+                            }
+                        },
+                        {
+                            text: 'Used Format Codes - Abbreviated - Same language as weekdays text/ Single Format per Row',
+                            onclick: function () {
+                                editor.insertContent('<table style="width: 100%;"><tbody><tr><td style="padding: 2pt; text-align: center; background-color: #000000;"><strong><span style="color: #fff;">Meeting Format Legend</span></strong></td></tr></tbody></table>[format_codes_used_basic_large]</p>');
                             }
                         },
                         {
@@ -51,9 +57,15 @@
                             }
                         },
                        {
-                            text: 'All Format Codes - Detailed - Same language as weekdays text',
+                            text: 'All Format Codes - Detailed - Same language as weekdays text/ Two Formats per Row',
                             onclick: function () {
                                 editor.insertContent('<table style="width: 100%;"><tbody><tr><td style="padding: 2pt; text-align: center; background-color: #000000;"><strong><span style="color: #fff;">Meeting Format Legend</span></strong></td></tr></tbody></table><p>[format_codes_all_detailed]</p>');
+                            }
+                        },
+                        {
+                            text: 'All Format Codes - Abbreviated - Same language as weekdays text/ Single Format per Row',
+                            onclick: function () {
+                                editor.insertContent('<table style="width: 100%;"><tbody><tr><td style="padding: 2pt; text-align: center; background-color: #000000;"><strong><span style="color: #fff;">Meeting Format Legend</span></strong></td></tr></tbody></table>[format_codes_used_basic_large]</p>');
                             }
                         },
                         {

--- a/bmlt-meeting-list.php
+++ b/bmlt-meeting-list.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Bread
  * Plugin URI:        https://bmlt.app
  * Description:       Maintains and generates PDF Meeting Lists from BMLT.
- * Version:           2.10.4
+ * Version:           2.10.5
  * Author:            bmlt-enabled
  * Author URI:        https://bmlt.app/
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ if (! defined('WPINC')) {
  * Start at version 2.8.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define('BREAD_VERSION', '2.10.4');
+define('BREAD_VERSION', '2.10.5');
 
 /**
  * The code that runs during plugin activation.

--- a/includes/class-bread-bmlt.php
+++ b/includes/class-bread-bmlt.php
@@ -52,7 +52,7 @@ class Bread_Bmlt
                 'User-Agent' => $this->bread->getOption('user_agent')
             );
         }
-        if ($this->bread->getOption('sslverify') == '1') {
+        if ($this->bread->getOption('sslverify')) {
             $args['sslverify'] = false;
         }
         return wp_remote_get($url, $args);
@@ -229,7 +229,7 @@ class Bread_Bmlt
         // only the name of the service body.  So we cache the value so it only
         // needs to be called once.
         if (!$this->default_query) {
-            $this->default_query = ($this->bread->getOption('recurse_service_bodies') == 1) ? '&recursive=1' : '';
+            $this->default_query = ($this->bread->getOption('recurse_service_bodies')) ? '&recursive=1' : '';
             for ($i=0; $i<count($this->bread->getOption('service_bodies')); $i++) {
                 $area_data = explode(',', $this->bread->getOption('service_bodies')[$i]);
                 $service_body_id = $this->bread->arraySafeGet($area_data, 1);

--- a/includes/class-bread.php
+++ b/includes/class-bread.php
@@ -696,6 +696,7 @@ class Bread
         $this->fillUnsetOption('page_fold', 'quad');
         $this->fillUnsetOption('meeting_sort', 'day');
         $this->fillUnsetStringOption('booklet_pages', false);
+        $this->fillUnsetOption('booklet_columns', 1);
         $this->fillUnsetStringOption('borough_suffix', 'Borough');
         $this->fillUnsetStringOption('county_suffix', 'County');
         $this->fillUnsetStringOption('neighborhood_suffix', 'Neighborhood');
@@ -721,6 +722,11 @@ class Bread
         $this->fillUnsetOption('include_additional_list', '0');
         $this->fillUnsetOption('additional_list_format_key', '');
         $this->fillUnsetOption('additional_list_sort_order', 'name');
+        if ($this->options['include_protection']) {
+            $this->fillUnsetStringOption('protection_password', '');
+        } else {
+            $this->options['protection_password'] = '';
+        }
         $this->fillUnsetStringOption('protection_password', '');
         $this->fillUnsetStringOption('custom_query', '');
         $this->fillUnsetStringOption('additional_list_custom_query', '');

--- a/includes/class-bread.php
+++ b/includes/class-bread.php
@@ -627,7 +627,7 @@ class Bread
     }
     private function fillUnsetOption($option, $default)
     {
-        if (!isset($this->options[$option]) || strlen(trim($this->options[$option])) == 0) {
+        if (!isset($this->options[$option]) || (is_string($this->options[$option]) && strlen(trim($this->options[$option])) === 0)) {
             $this->options[$option] = $default;
         }
     }
@@ -675,13 +675,13 @@ class Bread
         if (floatval($this->options['pageheader_fontsize']) < 4) {
             $this->options['pageheader_fontsize'] = 6;
         }
-        $this->fillUnsetOption('suppress_heading', 0);
+        $this->fillUnsetOption('suppress_heading', false);
         $this->fillUnsetOption('header_text_color', '#ffffff');
         $this->fillUnsetOption('header_background_color', '#000000');
         $this->fillUnsetOption('pageheader_textcolor', '#000000');
         $this->fillUnsetOption('pageheader_backgroundcolor', '#ffffff');
-        $this->fillUnsetOption('header_uppercase', '0');
-        $this->fillUnsetOption('header_bold', '1');
+        $this->fillUnsetOption('header_uppercase', false);
+        $this->fillUnsetOption('header_bold', true);
         $this->fillUnsetOption('sub_header_shown', 'none');
         $this->fillUnsetOption('margin_top', 3);
         $this->fillUnsetOption('margin_bottom', 3);
@@ -703,7 +703,7 @@ class Bread
         $this->fillUnsetStringOption('city_suffix', 'City');
         $this->fillUnsetStringOption('meeting_template_content', '');
         $this->fillUnsetStringOption('additional_list_template_content', '');
-        $this->fillUnsetOption('column_line', 0);
+        $this->fillUnsetOption('column_line', false);
         $this->fillUnsetOption('col_color', '#bfbfbf');
         $this->fillUnsetStringOption('custom_section_content', '');
         $this->fillUnsetOption('custom_section_line_height', '1');
@@ -713,13 +713,13 @@ class Bread
         $this->fillUnsetOption('base_font', 'dejavusanscondensed');
         $this->fillUnsetOption('colorspace', 0);
         $this->fillUnsetArrayOption('service_bodies', []);
-        $this->fillUnsetOption('recurse_service_bodies', 1);
-        $this->fillUnsetOption('extra_meetings_enabled', 0);
-        $this->fillUnsetOption('include_protection', 0);
+        $this->fillUnsetOption('recurse_service_bodies', true);
+        $this->fillUnsetOption('extra_meetings_enabled', false);
+        $this->fillUnsetOption('include_protection', false);
         $this->fillUnsetOption('weekday_language', 'en');
         $this->fillUnsetStringOption('additional_list_language', '');  // same as main language
         $this->fillUnsetOption('weekday_start', '1');
-        $this->fillUnsetOption('include_additional_list', '0');
+        $this->fillUnsetOption('include_additional_list', false);
         $this->fillUnsetOption('additional_list_format_key', '');
         $this->fillUnsetOption('additional_list_sort_order', 'name');
         if ($this->options['include_protection']) {
@@ -731,15 +731,15 @@ class Bread
         $this->fillUnsetStringOption('custom_query', '');
         $this->fillUnsetStringOption('additional_list_custom_query', '');
         $this->fillUnsetStringOption('user_agent', 'Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0) +bread');
-        $this->fillUnsetOption('sslverify', '0');
+        $this->fillUnsetOption('sslverify', false);
         $this->fillUnsetOption('cache_time', 0);
         $this->fillUnsetOption('wheelchair_size', "20px");
         $this->fillUnsetArrayOption('extra_meetings', []);
         if (!isset($this->options['extra_meetings'])) {
             if (count($this->options['extra_meetings']) > 0) {
-                $this->options['extra_meetings_enabled'] = 1;
+                $this->options['extra_meetings_enabled'] = true;
             } else {
-                $this->options['extra_meetings_enabled'] = 0;
+                $this->options['extra_meetings_enabled'] = false;
             }
         }
         $this->fillUnsetArrayOption('authors', []);
@@ -785,20 +785,6 @@ class Bread
                 $this->options['root_server'] = 'http://' . $this->options['root_server'];
             }
         }
-        if (!isset($this->options['cont_header_shown'])
-            && isset($this->options['page_height_fix'])
-        ) {
-            $fix = floatval($this->options['page_height_fix']);
-            // say, the height of 2 lines
-            $x = floatval($this->options['content_font_size']) *
-                floatval($this->options['content_line_height']) * 2.0 * 0.35; // pt to mm
-            if ($fix < $x) {
-                $this->options['cont_header_shown'] = true;
-            } else {
-                $this->options['cont_header_shown'] = false;
-            }
-            unset($this->options['page_height_fix']);
-        }
         if ($this->options['weekday_language'] == 'both') {
             $this->options['weekday_language'] = "en_es";
         }
@@ -816,6 +802,18 @@ class Bread
         $this->renamed_option('asm_language', 'additional_list_language');
         $this->renamed_option('asm_custom_query', 'additional_list_custom_query');
         $this->renamed_option('asm_template_content', 'additional_list_template_content');
+
+        $this->boolify_option('recurse_service_bodies');
+        $this->boolify_option('extra_meetings_enabled');
+        $this->boolify_option('include_protection');
+        $this->boolify_option('include_additional_list');
+        $this->boolify_option('column_line');
+        $this->boolify_option('sslverify');
+        $this->boolify_option('suppress_heading');
+        $this->boolify_option('header_uppercase');
+        $this->boolify_option('header_bold');
+        $this->boolify_option('cont_header_shown');
+
         if ($this->versionLessThan('2.8')) {
             if (($this->options['page_fold'] == 'half' || $this->options['page_fold'] == 'full') && isset($this->options['last_page_content']) && trim($this->options['last_page_content']) !== '') {
                 $this->options['custom_section_content'] = $this->options['last_page_content'];
@@ -883,6 +881,10 @@ class Bread
                 unset($this->options[$old]);
             }
         }
+    }
+    private function boolify_option(string $option)
+    {
+        $this->options[$option] = boolval($this->options[$option]);
     }
     /**
      * Stores the current settings in the Wordpress Options DB.

--- a/public/class-bread-content-generator.php
+++ b/public/class-bread-content-generator.php
@@ -189,6 +189,9 @@ class Bread_ContentGenerator
         $this->mpdf->SetColumns($num_columns, '', $this->options['column_gap']);
         if ($this->options['page_fold'] == 'half' || $this->options['page_fold'] == 'full') {
             $this->write_front_page();
+            if ($this->options['booklet_columns'] > 1) {
+                $this->mpdf->SetColumns(intval($this->options['booklet_columns']), '', $this->options['column_gap']);
+            }
         }
         $this->mpdf->WriteHTML('td{font-size: ' . $this->options['content_font_size'] . "pt;line-height:" . $this->options['content_line_height'] . ';background-color:#ffffff00;}', 1);
         $this->mpdf->SetDefaultBodyCSS('font-size', $this->options['content_font_size'] . 'pt');
@@ -364,9 +367,6 @@ class Bread_ContentGenerator
     private function writeMeetings(string $template, Bread_Meetingslist_Structure $meetingslistStructure): void
     {
         $template = wpautop(stripslashes($template));
-        // TODO: figure out why this is necessary
-        //$template = preg_replace('/[[:^print:]]/', ' ', $template);
-
         $template = str_replace("&nbsp;", " ", $template);
         $analysedTemplate = $this->analyseTemplate($template);
 
@@ -411,7 +411,11 @@ class Bread_ContentGenerator
     private function writeBreak(Mpdf $mpdf)
     {
         if ($this->options['page_fold'] === 'half' || $this->options['page_fold'] === 'full') {
-            $mpdf->WriteHTML("<pagebreak>");
+            if ($this->options['booklet_columns'] > 1) {
+                $mpdf->WriteHTML("<columnbreak />");
+            } else {
+                $mpdf->WriteHTML("<pagebreak />");
+            }
         } else {
             $mpdf->WriteHTML("<columnbreak />");
         }
@@ -535,14 +539,16 @@ class Bread_ContentGenerator
     {
         $lang = $this->options['weekday_language'];
         $this->shortcode_formats('[format_codes_used_basic]', false, $lang, false, $page_name, $data);
+        $this->shortcode_formats('[format_codes_used_basic_large]', false, $lang, false, $page_name, $data, true);
         $this->shortcode_formats('[format_codes_used_detailed]', true, $lang, false, $page_name, $data);
         $this->shortcode_formats('[format_codes_used_basic_es]', false, 'es', true, $page_name, $data);
         $this->shortcode_formats('[format_codes_used_detailed_es]', true, 'es', true, $page_name, $data);
         $this->shortcode_formats('[format_codes_used_basic_fr]', false, 'fr', true, $page_name, $data);
         $this->shortcode_formats('[format_codes_all_basic]', false, $lang, true, $page_name, $data);
+        $this->shortcode_formats('[format_codes_all_basic_large]', false, $lang, true, $page_name, $data, true);
         $this->shortcode_formats('[format_codes_all_detailed]', true, $lang, true, $page_name, $data);
     }
-    private function shortcode_formats($shortcode, $detailed, $lang, $isAll, $page, &$str)
+    private function shortcode_formats($shortcode, $detailed, $lang, $isAll, $page, &$str, $large = false)
     {
         $pos = strpos($str, $shortcode);
         if ($pos == false) {
@@ -552,7 +558,7 @@ class Bread_ContentGenerator
         if ($detailed) {
             $value = $this->formatsManager->write_detailed_formats($lang, $isAll, $this->options[$page . '_line_height'], $this->options[$page . '_font_size'] . "pt");
         } else {
-            $value = $this->formatsManager->write_formats($lang, $isAll, $this->options[$page . '_line_height'], $this->options[$page . '_font_size'] . "pt");
+            $value = $this->formatsManager->write_formats($lang, $isAll, $this->options[$page . '_line_height'], $this->options[$page . '_font_size'] . "pt", !$large);
         }
         $str = substr($str, 0, $pos) . $value . substr($str, $pos + strlen($shortcode));
     }

--- a/public/class-bread-content-generator.php
+++ b/public/class-bread-content-generator.php
@@ -190,17 +190,16 @@ class Bread_ContentGenerator
         if ($this->options['page_fold'] == 'half' || $this->options['page_fold'] == 'full') {
             $this->write_front_page();
             if ($this->options['booklet_columns'] > 1) {
-                $this->mpdf->SetColumns(intval($this->options['booklet_columns']), '', $this->options['column_gap']);
+                $this->mpdf->SetColumns($this->options['booklet_columns'], '', $this->options['column_gap']);
             }
         }
-        $this->mpdf->WriteHTML('td{font-size: ' . $this->options['content_font_size'] . "pt;line-height:" . $this->options['content_line_height'] . ';background-color:#ffffff00;}', 1);
+        $this->mpdf->WriteHTML('td{font-size: ' . $this->options['content_font_size'] . "pt;line-height:" . $this->options['content_line_height'] . ';}', 1);
         $this->mpdf->SetDefaultBodyCSS('font-size', $this->options['content_font_size'] . 'pt');
         $this->mpdf->SetDefaultBodyCSS('line-height', $this->options['content_line_height']);
         $lang = $this->options['weekday_language'];
         if ($lang == 'fa') {
             $this->mpdf->SetDefaultBodyCSS('direction', 'rtl');
         }
-        $this->mpdf->SetDefaultBodyCSS('background-color', '#ffffff00');
         if ($this->options['page_fold'] == 'half' || $this->options['page_fold'] == 'full') {
             $this->WriteHTML('<sethtmlpagefooter name="Meeting1Footer" page="ALL" />');
         }
@@ -208,7 +207,7 @@ class Bread_ContentGenerator
         foreach ($this->result_meetings as &$value) {
             $value = $this->meetingEnhancer->enhance_meeting($value, $lang, $this->formatsManager);
         }
-        $meetingslistStructure = new Bread_Meetingslist_Structure($this->bread, $this->result_meetings, $lang, $this->options['include_additional_list'] == 0 ? -1 : 0);
+        $meetingslistStructure = new Bread_Meetingslist_Structure($this->bread, $this->result_meetings, $lang, $this->options['include_additional_list'] ? 0 : -1);
         $this->writeMeetings($this->options['meeting_template_content'], $meetingslistStructure);
 
         if ($this->options['page_fold'] !== 'half' && $this->options['page_fold'] !== 'full') {
@@ -340,7 +339,7 @@ class Bread_ContentGenerator
         $this->mpdf->SetDefaultBodyCSS('font-size', $this->options['custom_section_font_size'] . 'pt');
         $this->mpdf->SetDefaultBodyCSS('background-color', '#ffffff00');
         $data = $this->standard_shortcode_replacement('custom_section');
-        $this->mpdf->WriteHTML('td{font-size: ' . $this->options['custom_section_font_size'] . "pt;line-height:" . $this->options['custom_section_line_height'] . ';}', 1);
+        //$this->mpdf->WriteHTML('td{font-size: ' . $this->options['custom_section_font_size'] . "pt;line-height:" . $this->options['custom_section_line_height'] . ';}', 1);
         $this->writeHTMLwithAdditionalMeetinglist($data);
     }
     /**

--- a/public/class-bread-format-manager.php
+++ b/public/class-bread-format-manager.php
@@ -220,7 +220,7 @@ class Bread_FormatsManager
      * @param string $fontSize
      * @return void
      */
-    public function write_formats(string $lang, bool $isAll, string $lineHeight, string $fontSize)
+    public function write_formats(string $lang, bool $isAll, string $lineHeight, string $fontSize, bool $isTwoPerRow = true)
     {
         $formats = $isAll ? $this->getAllFormats($lang) : $this->getFormatsUsed($lang);
         if (empty($formats)) {
@@ -232,12 +232,14 @@ class Bread_FormatsManager
             $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";padding-left:4px;border:1px solid #555;border-right:0;width:12%;vertical-align:top;'>" . $formats[$count]['key_string'] . "</td>";
             $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";border: 1px solid #555;border-left:0;width:38%;vertical-align:top;'>" . $formats[$count]['name_string'] . "</td>";
             $count++;
-            if ($count >= count($formats)) {
-                $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";padding-left:4px;border: 1px solid #555;border-right:0;width:12%;vertical-align:top;'></td>";
-                $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";border: 1px solid #555;border-left:0;width:38%;vertical-align:top;'></td>";
-            } else {
-                $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";padding-left:4px;border: 1px solid #555;border-right:0;width:12%;vertical-align:top;'>" . $formats[$count]['key_string'] . "</td>";
-                $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";border: 1px solid #555;border-left:0;width:38%;vertical-align:top;'>" . $formats[$count]['name_string'] . "</td>";
+            if ($isTwoPerRow) {
+                if ($count >= count($formats)) {
+                    $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";padding-left:4px;border: 1px solid #555;border-right:0;width:12%;vertical-align:top;'></td>";
+                    $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";border: 1px solid #555;border-left:0;width:38%;vertical-align:top;'></td>";
+                } else {
+                    $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";padding-left:4px;border: 1px solid #555;border-right:0;width:12%;vertical-align:top;'>" . $formats[$count]['key_string'] . "</td>";
+                    $data .= "<td style='font-size:" . $fontSize . "pt;line-height:" . $lineHeight . ";border: 1px solid #555;border-left:0;width:38%;vertical-align:top;'>" . $formats[$count]['name_string'] . "</td>";
+                }
             }
             $data .= "</tr>";
         }

--- a/public/class-bread-meeting-enhancer.php
+++ b/public/class-bread-meeting-enhancer.php
@@ -28,7 +28,7 @@ class Bread_Meeting_Enhancer
             $meeting_value['duration_m'] = $minutes;
             $meeting_value['duration_h'] = rtrim(rtrim(number_format($minutes / 60, 2), 0), '.');
             $space = ' ';
-            if ($this->options['remove_space'] == 1) {
+            if ($this->options['remove_space']) {
                 $space = '';
             }
             if ($this->options['time_clock'] == null || $this->options['time_clock'] == '12' || $this->options['time_option'] == '') {

--- a/public/class-bread-meetingslist-structure.php
+++ b/public/class-bread-meetingslist-structure.php
@@ -155,7 +155,7 @@ class Bread_Meetingslist_Structure
     {
         $this->bread = $bread;
         $this->options = $bread->getOptions();
-        $this->suppress_heading = $this->options['suppress_heading'] == 1;
+        $this->suppress_heading = $this->options['suppress_heading'];
 
         $meeting_sort = $this->options['meeting_sort'];
         if ($include_additional_list > 0) {
@@ -180,14 +180,13 @@ class Bread_Meetingslist_Structure
         $header_style .= "line-height:" . $this->options['content_line_height'] . ";";
         $header_style .= "text-align:center;padding-top:2px;padding-bottom:3px;";
 
-        if ($this->options['header_uppercase'] == 1) {
+        if ($this->options['header_uppercase']) {
             $header_style .= 'text-transform: uppercase;';
         }
-        if ($this->options['header_bold'] == 0) {
-            $header_style .= 'font-weight: normal;';
-        }
-        if ($this->options['header_bold'] == 1) {
+        if ($this->options['header_bold']) {
             $header_style .= 'font-weight: bold;';
+        } else {
+            $header_style .= 'font-weight: normal;';
         }
         $this->header_style = $header_style;
         $this->cont = '(' . $bread->getTranslateTable()[$lang]['CONT'] . ')';
@@ -263,7 +262,7 @@ class Bread_Meetingslist_Structure
         $levels = $this->getHeaderLevels();
         $headerMeetings = array();
         foreach ($result_meetings as &$value) {
-            $additional_list_test = $this->additional_list_test($value, $include_additional_list == 1);
+            $additional_list_test = $this->additional_list_test($value, $include_additional_list === 1);
             if ((($include_additional_list < 0 && $additional_list_test) ||
                 ($include_additional_list > 0 && !$additional_list_test))) {
                 continue;

--- a/public/class-bread-public.php
+++ b/public/class-bread-public.php
@@ -242,7 +242,7 @@ class Bread_Public
         $header_stylesheet = (new WP_Filesystem_Direct(null))->get_contents(plugin_dir_path(__FILE__) . 'css/mpdfstyletables.css');
         $this->mpdf->WriteHTML($header_stylesheet, 1); // The parameter 1 tells that this is css/style only and no body/html/text
         $this->mpdf->SetDefaultBodyCSS('line-height', $this->options['content_line_height']);
-        if ($this->options['column_line'] && ($this->options['page_fold'] === 'tri' || $this->options['page_fold'] === 'quad') ) {
+        if ($this->options['column_line'] && ($this->options['page_fold'] === 'tri' || $this->options['page_fold'] === 'quad')) {
             $this->drawLinesSeperatingColumns($mpdf_init_options['format'], $default_font);
         }
         $result = $this->bread->bmlt()->doMainQuery();

--- a/public/class-bread-public.php
+++ b/public/class-bread-public.php
@@ -213,11 +213,11 @@ class Bread_Public
         require_once __DIR__ . '/class-bread-format-manager.php';
         $default_font = $this->options['base_font'];
         $mpdf_init_options = $this->construct_init_options($default_font);
-        if (isset($this->options['packTabledata']) && $this->options['packTabledata']) {
+        if ($this->options['packTabledata']) {
             $mpdf_init_options['packTabledata'] = true;
         }
         $this->mpdf = @new mPDF($mpdf_init_options);
-        if (isset($this->options['logging']) && $this->options['logging']) {
+        if ($this->options['logging']) {
             $logger = new Logger('bread-log');
             $site = '';
             if (is_multisite()) {
@@ -228,7 +228,7 @@ class Bread_Public
             $this->mpdf->showImageErrors = true;
             $this->mpdf->setLogger($logger);
         }
-        if (isset($this->options['simpleTables']) && $this->options['simpleTables']) {
+        if ($this->options['simpleTables']) {
             $this->mpdf->simpleTables = true;
         }
         $this->mpdf->setAutoBottomMargin = 'pad';
@@ -242,10 +242,7 @@ class Bread_Public
         $header_stylesheet = (new WP_Filesystem_Direct(null))->get_contents(plugin_dir_path(__FILE__) . 'css/mpdfstyletables.css');
         $this->mpdf->WriteHTML($header_stylesheet, 1); // The parameter 1 tells that this is css/style only and no body/html/text
         $this->mpdf->SetDefaultBodyCSS('line-height', $this->options['content_line_height']);
-        $this->mpdf->SetDefaultBodyCSS('background-color', '#ffffff00');
-        if ($this->options['column_line'] == 1
-            && ($this->options['page_fold'] == 'tri' || $this->options['page_fold'] == 'quad')
-        ) {
+        if ($this->options['column_line'] && ($this->options['page_fold'] === 'tri' || $this->options['page_fold'] === 'quad') ) {
             $this->drawLinesSeperatingColumns($mpdf_init_options['format'], $default_font);
         }
         $result = $this->bread->bmlt()->doMainQuery();
@@ -298,7 +295,7 @@ class Bread_Public
         $generator->generate($num_columns);
         $this->mpdf->SetDisplayMode('fullpage', 'two');
         $this->reorder_booklet_pages();
-        if ($this->options['include_protection'] == 1) {
+        if ($this->options['include_protection']) {
             // 'copy','print','modify','annot-forms','fill-forms','extract','assemble','print-highres'
             $this->mpdf->SetProtection(array('copy', 'print', 'print-highres'), '', $this->options['protection_password']);
         }
@@ -453,7 +450,7 @@ class Bread_Public
         $FilePath = $this->bread->temp_dir() . DIRECTORY_SEPARATOR . $this->get_FilePath('_column');
         $mpdf_column->Output($FilePath, 'F');
         $pagecount = $this->mpdf->SetSourceFile($FilePath);
-        $tplId = $this->mpdf->importPage($pagecount);
+        $tplId = $this->mpdf->ImportPage($pagecount);
         $this->mpdf->SetPageTemplate($tplId);
     }
     private function addFontOptions(array $options): array
@@ -579,7 +576,6 @@ class Bread_Public
             $tplIdx = $mpdftmp->importPage(1);
             $mpdftmp->UseTemplate($tplIdx, 0, 0);
             $mpdftmp->UseTemplate($tplIdx, 0, $fh);
-            $sep = $this->columnSeparators($oh);
             $mpdftmp->AddPage($orientation);
             $tplIdx = $mpdftmp->ImportPage(2);
             $mpdftmp->UseTemplate($tplIdx, 0, 0);
@@ -661,7 +657,7 @@ class Bread_Public
     }
     private function columnSeparators($oh)
     {
-        if ($this->options['column_line'] == 1) {
+        if ($this->options['column_line']) {
             return '<body style="background:none;">
             <table style="background: none;width: 100%; height:' . $oh . 'mm border-collapse: collapse;">
                 <tbody>

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,8 @@ Follow all these steps, keep in mind that once you start using bread, it's not g
 = 2.10.5 =
 * Booklets can have 2 columns per page.
 * Formats table can have single format per row.
+* Fix problem where column separator lines were not printing.
+* Checkboxes consistently represented by booleans.
 
 = 2.10.4 =
 * Fix wizard crashing (#253)

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: meeting list, bmlt, narcotics anonymous, na
 Requires PHP: 8.1
 Requires at least: 6.2
 Tested up to: 7.0
-Stable tag: 2.10.4
+Stable tag: 2.10.5
 
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -54,6 +54,10 @@ Follow all these steps, keep in mind that once you start using bread, it's not g
 - Read here for more information: https://github.com/bmlt-enabled/bread/blob/main/contribute.md
 
 == Changelog ==
+
+= 2.10.5 =
+* Booklets can have 2 columns per page.
+* Formats table can have single format per row.
 
 = 2.10.4 =
 * Fix wizard crashing (#253)

--- a/tests/BreadMeetinglistStructureTest.php
+++ b/tests/BreadMeetinglistStructureTest.php
@@ -40,14 +40,13 @@ final class BreadMeetinglistStructureTest extends TestCase
         $header_style .= "font-size:" . $options['header_font_size'] . "pt;";
         $header_style .= "line-height:" . $options['content_line_height'] . ";";
         $header_style .= "text-align:center;padding-top:2px;padding-bottom:3px;";
-        if ($options['header_uppercase'] == 1) {
+        if ($options['header_uppercase']) {
             $header_style .= 'text-transform: uppercase;';
         }
-        if ($options['header_bold'] == 0) {
-            $header_style .= 'font-weight: normal;';
-        }
-        if ($options['header_bold'] == 1) {
+        if ($options['header_bold']) {
             $header_style .= 'font-weight: bold;';
+        } else {
+            $header_style .= 'font-weight: normal;';
         }
         return $header_style;
     }


### PR DESCRIPTION
* Booklets can have 2 columns per page.
* Formats table can have single format per row ([format_codes_used_basic_large]).
* Fix problem where column separator lines were not printing.
* Checkboxes consistently represented by booleans.